### PR TITLE
Fix EOF token parsing

### DIFF
--- a/src/dialect/snowflake.rs
+++ b/src/dialect/snowflake.rs
@@ -965,7 +965,6 @@ fn parse_session_options(parser: &mut Parser, set: bool) -> Result<Vec<DataLoadi
 
     loop {
         match parser.next_token().token {
-            Token::EOF => break,
             Token::Comma => continue, // Skip commas and continue to the next iteration
             Token::Word(key) => {
                 if set {
@@ -980,7 +979,12 @@ fn parse_session_options(parser: &mut Parser, set: bool) -> Result<Vec<DataLoadi
                 }
 
             },
-            _ => parser.expected("another option", parser.peek_token()),
+            _ => {
+                if parser.peek_token().token == Token::EOF {
+                    break
+                }
+                parser.expected("another option", parser.peek_token())
+            },
         }?;
     }
     Ok(options)

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -3292,7 +3292,7 @@ fn test_alter_session() {
     snowflake().verified_stmt("ALTER SESSION UNSET AUTOCOMMIT");
     snowflake().verified_stmt("ALTER SESSION UNSET AUTOCOMMIT QUERY_TAG");
     snowflake().one_statement_parses_to(
-        "ALTER SESSION SET A=false, B='tag'",
+        "ALTER SESSION SET A=false, B='tag';",
         "ALTER SESSION SET A=FALSE B='tag'",
     );
     snowflake().one_statement_parses_to(


### PR DESCRIPTION
```alter session set query_tag = 'snowplow_dbt'``` works
```alter session set query_tag = 'snowplow_dbt';``` not works
parser.next_token() skip EOF and empty spaces. EOF should be taken into account 